### PR TITLE
Update to iOS platform plugin's connector lifecycle

### DIFF
--- a/src/ios/vidyoconnector/VidyoViewController.h
+++ b/src/ios/vidyoconnector/VidyoViewController.h
@@ -18,14 +18,16 @@ enum VIDYO_CONNECTOR_STATE {
     VC_CONNECTION_FAILURE
 };
 
-@interface VidyoViewController : UIViewController <UITextFieldDelegate, VCConnectorIConnect, VCConnectorIRegisterLogEventListener> {
+@interface VidyoViewController : UIViewController <UITextFieldDelegate, VCConnectorIConnect, VCConnectorIRegisterLocalCameraEventListener, VCConnectorIRegisterLogEventListener> {
 @private
     VCConnector *vc;
+    VCLocalCamera *lastSelectedCamera;
     Logger    *logger;
     UIImage   *callStartImage;
     UIImage   *callEndImage;
     BOOL      microphonePrivacy;
     BOOL      cameraPrivacy;
+    BOOL      devicesSelected;
     BOOL      hideConfig;
     BOOL      autoJoin;
     BOOL      allowReconnect;


### PR DESCRIPTION
- Release devices when not yet connected and app goes to background;
- Mute camera when Connected and app goes to background;
- Release resources when controller is destroyed (Previously it was holding devices and resources upon app termination)